### PR TITLE
Patch to allow Python to built on Ubuntu...

### DIFF
--- a/package/python/python-2.7-015-ac-version-check.patch
+++ b/package/python/python-2.7-015-ac-version-check.patch
@@ -1,0 +1,25 @@
+--- host-python-2.7.1/configure.in-orig	2016-02-25 20:35:38.232646000 -0500
++++ host-python-2.7.1/configure.in	2016-02-25 20:36:18.570774521 -0500
+@@ -5,14 +5,14 @@
+ # Set VERSION so we only need to edit in one place (i.e., here)
+ m4_define(PYTHON_VERSION, 2.7)
+ 
+-dnl Some m4 magic to ensure that the configure script is generated
+-dnl by the correct autoconf version.
+-m4_define([version_required],
+-[m4_if(m4_version_compare(m4_defn([m4_PACKAGE_VERSION]), [$1]), 0,
+-       [],
+-       [m4_fatal([Autoconf version $1 is required for Python], 63)])
+-])
+-version_required(2.65)
++#dnl Some m4 magic to ensure that the configure script is generated
++#dnl by the correct autoconf version.
++#m4_define([version_required],
++#[m4_if(m4_version_compare(m4_defn([m4_PACKAGE_VERSION]), [$1]), 0,
++#       [],
++#       [m4_fatal([Autoconf version $1 is required for Python], 63)])
++#])
++#version_required(2.65)
+ 
+ AC_REVISION($Revision: 86076 $)
+ AC_INIT(python, PYTHON_VERSION, http://bugs.python.org/)


### PR DESCRIPTION
removes bad version check on autoconf.  This is required in order to build AstLinux with python on Ubuntu.