### PR TITLE
Patch to allow crosstools-ng to build on Ubuntu 17.04

### DIFF
--- a/crosstool-ng-src/patches/gcc/4.8.3/130-build_gcc-5_with_gcc-6.patch
+++ b/crosstool-ng-src/patches/gcc/4.8.3/130-build_gcc-5_with_gcc-6.patch
@@ -1,0 +1,122 @@
+diff -Naur a/gcc/cp/cfns.gperf b/gcc/cp/cfns.gperf
+--- a/gcc/cp/cfns.gperf	2013-01-10 15:38:27.000000000 -0500
++++ b/gcc/cp/cfns.gperf	2017-04-25 21:04:21.429686516 -0400
+@@ -1,4 +1,5 @@
+-%{
++%language=C++
++%define class-name libc_name%{
+ /* Copyright (C) 2000-2013 Free Software Foundation, Inc.
+ 
+ This file is part of GCC.
+@@ -16,14 +17,6 @@
+ You should have received a copy of the GNU General Public License
+ along with GCC; see the file COPYING3.  If not see
+ <http://www.gnu.org/licenses/>.  */
+-#ifdef __GNUC__
+-__inline
+-#endif
+-static unsigned int hash (const char *, unsigned int);
+-#ifdef __GNUC__
+-__inline
+-#endif
+-const char * libc_name_p (const char *, unsigned int);
+ %}
+ %%
+ # The standard C library functions, for feeding to gperf; the result is used
+diff -Naur a/gcc/cp/cfns.h b/gcc/cp/cfns.h
+--- a/gcc/cp/cfns.h	2013-01-10 15:38:27.000000000 -0500
++++ b/gcc/cp/cfns.h	2017-04-25 21:04:34.456607200 -0400
+@@ -1,5 +1,5 @@
+-/* ANSI-C code produced by gperf version 3.0.3 */
+-/* Command-line: gperf -o -C -E -k '1-6,$' -j1 -D -N libc_name_p -L ANSI-C cfns.gperf  */
++/* C++ code produced by gperf version 3.0.4 */
++/* Command-line: gperf -o -C -E -k '1-6,$' -j1 -D -N libc_name_p -L C++ --output-file cfns.h cfns.gperf  */
+ 
+ #if !((' ' == 32) && ('!' == 33) && ('"' == 34) && ('#' == 35) \
+       && ('%' == 37) && ('&' == 38) && ('\'' == 39) && ('(' == 40) \
+@@ -28,7 +28,7 @@
+ #error "gperf generated tables don't work with this execution character set. Please report a bug to <bug-gnu-gperf@gnu.org>."
+ #endif
+ 
+-#line 1 "cfns.gperf"
++#line 3 "cfns.gperf"
+ 
+ /* Copyright (C) 2000-2013 Free Software Foundation, Inc.
+ 
+@@ -47,25 +47,18 @@
+ You should have received a copy of the GNU General Public License
+ along with GCC; see the file COPYING3.  If not see
+ <http://www.gnu.org/licenses/>.  */
+-#ifdef __GNUC__
+-__inline
+-#endif
+-static unsigned int hash (const char *, unsigned int);
+-#ifdef __GNUC__
+-__inline
+-#endif
+-const char * libc_name_p (const char *, unsigned int);
+ /* maximum key range = 391, duplicates = 0 */
+ 
+-#ifdef __GNUC__
+-__inline
+-#else
+-#ifdef __cplusplus
+-inline
+-#endif
+-#endif
+-static unsigned int
+-hash (register const char *str, register unsigned int len)
++class libc_name
++{
++private:
++  static inline unsigned int hash (const char *str, unsigned int len);
++public:
++  static const char *libc_name_p (const char *str, unsigned int len);
++};
++
++inline unsigned int
++libc_name::hash (register const char *str, register unsigned int len)
+ {
+   static const unsigned short asso_values[] =
+     {
+@@ -122,14 +115,8 @@
+   return hval + asso_values[(unsigned char)str[len - 1]];
+ }
+ 
+-#ifdef __GNUC__
+-__inline
+-#ifdef __GNUC_STDC_INLINE__
+-__attribute__ ((__gnu_inline__))
+-#endif
+-#endif
+ const char *
+-libc_name_p (register const char *str, register unsigned int len)
++libc_name::libc_name_p (register const char *str, register unsigned int len)
+ {
+   enum
+     {
+diff -Naur a/gcc/cp/except.c b/gcc/cp/except.c
+--- a/gcc/cp/except.c	2013-10-25 09:49:48.000000000 -0400
++++ b/gcc/cp/except.c	2017-04-25 19:59:07.721801113 -0400
+@@ -1025,7 +1025,8 @@
+      unless the system headers are playing rename tricks, and if
+      they are, we don't want to be confused by them.  */
+   id = DECL_NAME (fn);
+-  return !!libc_name_p (IDENTIFIER_POINTER (id), IDENTIFIER_LENGTH (id));
++  return !!libc_name::libc_name_p (IDENTIFIER_POINTER (id),
++				   IDENTIFIER_LENGTH (id));
+ }
+ 
+ /* Returns nonzero if an exception of type FROM will be caught by a
+diff -Naur a/gcc/cp/Make-lang.in b/gcc/cp/Make-lang.in
+--- a/gcc/cp/Make-lang.in	2013-01-10 15:38:27.000000000 -0500
++++ b/gcc/cp/Make-lang.in	2017-04-25 19:59:07.717801865 -0400
+@@ -115,7 +115,7 @@
+ # deleting the $(srcdir)/cp/cfns.h file.
+ $(srcdir)/cp/cfns.h:
+ endif
+-	gperf -o -C -E -k '1-6,$$' -j1 -D -N 'libc_name_p' -L ANSI-C \
++	gperf -o -C -E -k '1-6,$$' -j1 -D -N 'libc_name_p' -L C++ \
+ 		$(srcdir)/cp/cfns.gperf --output-file $(srcdir)/cp/cfns.h
+ 
+ #


### PR DESCRIPTION
Required in order to build crosstools on newer versions of Ubuntu