### PR TITLE
Patch to allow libglib2 to build on Ubuntu

### DIFF
--- a/package/libglib2/libglib2-0003-glib-gdate-suppress-string-format-literal-warning.patch
+++ b/package/libglib2/libglib2-0003-glib-gdate-suppress-string-format-literal-warning.patch
@@ -1,0 +1,20 @@
+Index: glib/glib/gdate.c
+===================================================================
+--- a/glib/gdate.c
++++ b/glib/gdate.c
+@@ -2439,6 +2439,9 @@ win32_strftime_helper (const GDate     *d,
+  *
+  * Returns: number of characters written to the buffer, or 0 the buffer was too small
+  */
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wformat-nonliteral"
++
+ gsize     
+ g_date_strftime (gchar       *s, 
+                  gsize        slen, 
+@@ -2549,3 +2552,5 @@ g_date_strftime (gchar       *s,
+   return retval;
+ #endif
+ }
++
++#pragma GCC diagnostic pop


### PR DESCRIPTION
This patch tells newer gcc compilers to ignore a specific warning.  Older compilers ignored by default but that changed somewhere along the lines now build aborts when the format-nonliteral warning occurs.  This patch tells the compiler to keep going as was previous behavior.  Default astlinux does not require libglib2, but it is required when building qemu.